### PR TITLE
Move Uberbukkit config entries from PoseidonConfig to UberbukkitConfig

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -172,65 +172,6 @@ public class PoseidonConfig extends Configuration {
 
         generateConfigOption("settings.exempt-staff-from-flight-kick", false);
 
-        // Uberbukkit settings
-        generateConfigOption("version.worldgen.cocoabeans_loot", true);
-        generateConfigOption("version.worldgen.pre_b1_2_ore_generation", false);
-        generateConfigOption("version.worldgen.pre_b1_2_tree_generation", false);
-        generateConfigOption("version.worldgen.generate_sandstone", true);
-        generateConfigOption("version.worldgen.biomes.generate_spruces", true);
-        generateConfigOption("version.worldgen.biomes.generate_birches", true);
-        generateConfigOption("version.worldgen.generate_steveco_chests", false);
-        generateConfigOption("version.worldgen.generate_lapis_ores", true);
-        generateConfigOption("version.worldgen.generate_tallgrass", true);
-        generateConfigOption("version.worldgen.ores.world.custom_seed", false);
-        generateConfigOption("version.worldgen.ores.world.seed", 0L);
-
-        generateConfigOption("version.mechanics.tile_grass_drop_seeds", false);
-        generateConfigOption("version.mechanics.flammable_fences_stairs", true);
-        generateConfigOption("version.mechanics.glowstone_pre1_6_6", false);
-        generateConfigOption("version.mechanics.wool_recipe_pre1_6_6", false);
-        generateConfigOption("version.mechanics.allow_grow_tallgrass", true);
-        generateConfigOption("version.mechanics.allow_1_7_fence_placement", true);
-        generateConfigOption("version.mechanics.tnt_require_lighter", true);
-        generateConfigOption("version.mechanics.sheep_drop_wool_on_punch", false);
-        generateConfigOption("version.mechanics.mushroom_spread", true);
-        generateConfigOption("version.mechanics.ice_generate_only_when_snowing", false);
-        generateConfigOption("version.mechanics.pre_1_6_fire", false);
-        generateConfigOption("version.mechanics.nether_bed_explode", true);
-        generateConfigOption("version.mechanics.arrows_pickup_by_others", true);
-        generateConfigOption("version.mechanics.allow_minecart_boosters", false);
-        generateConfigOption("version.mechanics.spawn_squids", true);
-        generateConfigOption("version.mechanics.spawn_wolves", true);
-        generateConfigOption("version.mechanics.spawn_slimes", true);
-        generateConfigOption("version.mechanics.do_weather", true);
-        generateConfigOption("version.mechanics.allow_ladder_gap", false);
-        generateConfigOption("version.mechanics.old_slab_recipe", false);
-        generateConfigOption("version.mechanics.burning_pig_drop_cooked_meat", true);
-        generateConfigOption("version.mechanics.spawn_sheep_with_shades_of_black", true);
-        generateConfigOption("version.mechanics.spawn_brown_and_pink_sheep", true);
-        generateConfigOption("version.mechanics.drop_saplings_of_leaf_type", true);
-        generateConfigOption("version.mechanics.spiders_trample_crops", false);
-        generateConfigOption("version.mechanics.spiders_climb_walls", true);
-        generateConfigOption("version.mechanics.allow_blocks_at_y_127", false);
-        generateConfigOption("version.mechanics.drop_lapis_as_b1_2", false);
-        generateConfigOption("version.mechanics.allow_milking_squids", false);
-        generateConfigOption("version.mechanics.pre_b1_6_block_opacity", false);
-        generateConfigOption("version.mechanics.pre_b1_5_pumpkins", false);
-        generateConfigOption("version.mechanics.allow_bone_meal_on_grass", true);
-        generateConfigOption("version.mechanics.beds_pre_b1_6_5", false);
-        generateConfigOption("version.mechanics.pre_b1_5_block_placement_rules", false);
-        generateConfigOption("version.mechanics.trample_farmland_above_fence", false);
-        generateConfigOption("version.mechanics.seeds_replace_blocks", false);
-
-        generateConfigOption("version.mechanics.boats.drop_boat_not_wood", false);
-        generateConfigOption("version.mechanics.boats.break_boat_on_collision", true);
-
-        generateConfigOption("version.experimental.force_fix_chunk_coords_corruption", false);
-        generateConfigOption("version.allow_join.protocol", "14");
-        generateConfigOption("version.allow_join.info", "Specify client versions to accept (separated by commas - first PVN is treated as target PVN of the server)");
-        generateConfigOption("version.allow_join.pvns_of_versions", "6 - a1.2.3_05 to a1.2.6; 7 - b1.0 to b1.1_02; 8 - b1.2 to b1.2_02; 9 - b1.3(_01); 10 - b1.4(_01); 11 - b1.5(_01); 12 - b1.6_test_build_3; 13 - b1.6 to b1.6.6, 14 - b1.7 to b1.7.3");
-        generateConfigOption("version.mechanics.beds_set_spawnpoint", true);
-
         generateConfigOption("fix.illegal-container-interaction.info", "Prevents interactions in a container if the player is farther away than the max distance.");
         generateConfigOption("fix.illegal-container-interaction.max-distance", 4);
         generateConfigOption("fix.illegal-container-interaction.log-violation", false);

--- a/src/main/java/net/minecraft/server/BiomeBase.java
+++ b/src/main/java/net/minecraft/server/BiomeBase.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BiomeBase {
 
@@ -50,10 +50,10 @@ public class BiomeBase {
         this.t.add(new BiomeMeta(EntityChicken.class, 10));
         this.t.add(new BiomeMeta(EntityCow.class, 8));
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.spawn_squids", true))
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.spawn_squids", true))
             this.u.add(new BiomeMeta(EntitySquid.class, 10));
 
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.spawn_slimes", true))
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.spawn_slimes", true))
             this.s.add(new BiomeMeta(EntitySlime.class, 10));
     }
 

--- a/src/main/java/net/minecraft/server/BiomeForest.java
+++ b/src/main/java/net/minecraft/server/BiomeForest.java
@@ -2,19 +2,19 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BiomeForest extends BiomeBase {
 
     public BiomeForest() {
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.spawn_wolves", true))
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.spawn_wolves", true))
             this.t.add(new BiomeMeta(EntityWolf.class, 2));
     }
 
     public WorldGenerator a(Random random) {
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.biomes.generate_birches", true) && random.nextInt(5) == 0) {
+        if (UberbukkitConfig.getInstance().getBoolean("worldgen.biomes.generate_birches", true) && random.nextInt(5) == 0) {
             return new WorldGenForest();
         } else if (random.nextInt(3) == 0) {
             return new WorldGenBigTree();

--- a/src/main/java/net/minecraft/server/BiomeTaiga.java
+++ b/src/main/java/net/minecraft/server/BiomeTaiga.java
@@ -2,19 +2,19 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BiomeTaiga extends BiomeBase {
 
     public BiomeTaiga() {
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.spawn_wolves", true))
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.spawn_wolves", true))
             this.t.add(new BiomeMeta(EntityWolf.class, 2));
     }
 
     public WorldGenerator a(Random random) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.worldgen.biomes.generate_spruces", true))
+        if (!UberbukkitConfig.getInstance().getBoolean("worldgen.biomes.generate_spruces", true))
             return super.a(random);
 
         return (WorldGenerator) (random.nextInt(3) == 0 ? new WorldGenTaiga1() : new WorldGenTaiga2());

--- a/src/main/java/net/minecraft/server/Block.java
+++ b/src/main/java/net/minecraft/server/Block.java
@@ -1,6 +1,7 @@
 package net.minecraft.server;
 
 import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -116,14 +117,14 @@ public class Block {
     public static final Block NETHERRACK = (new BlockBloodStone(87, 103)).c(0.4F).a(h).a("hellrock");
     public static final Block SOUL_SAND = (new BlockSlowSand(88, 104)).c(0.5F).a(l).a("hellsand");
     // uberbukkit
-    public static final Block GLOWSTONE = !PoseidonConfig.getInstance().getBoolean("version.mechanics.glowstone_pre1_6_6", false) ? (new BlockLightStone(89, 105, Material.STONE)).c(0.3F).a(j).a(1.0F).a("lightgem") : (new BlockLightStone(89, 105, Material.SHATTERABLE)).c(0.3F).a(j).a(1.0F).a("lightgem");
+    public static final Block GLOWSTONE = !UberbukkitConfig.getInstance().getBoolean("mechanics.glowstone_pre1_6_6", false) ? (new BlockLightStone(89, 105, Material.STONE)).c(0.3F).a(j).a(1.0F).a("lightgem") : (new BlockLightStone(89, 105, Material.SHATTERABLE)).c(0.3F).a(j).a(1.0F).a("lightgem");
     public static final BlockPortal PORTAL = (BlockPortal) (new BlockPortal(90, 14)).c(-1.0F).a(j).a(0.75F).a("portal");
     public static final Block JACK_O_LANTERN = (new BlockPumpkin(91, 102, true)).c(1.0F).a(e).a(1.0F).a("litpumpkin").g();
     public static final Block CAKE_BLOCK = (new BlockCake(92, 121)).c(0.5F).a(k).a("cake").n().g();
     public static final Block DIODE_OFF = (new BlockDiode(93, false)).c(0.0F).a(e).a("diode").n().g();
     public static final Block DIODE_ON = (new BlockDiode(94, true)).c(0.0F).a(0.625F).a(e).a("diode").n().g();
     // uberbukkit
-    public static final Block LOCKED_CHEST = !PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_steveco_chests", false) ? (new BlockLockedChest(95)).c(0.0F).a(1.0F).a(e).a("lockedchest").a(true).g() : (new BlockLockedChest(95)).c(-1.0F).a(1.0F).a(e).a("lockedchest").g();
+    public static final Block LOCKED_CHEST = !UberbukkitConfig.getInstance().getBoolean("worldgen.generate_steveco_chests", false) ? (new BlockLockedChest(95)).c(0.0F).a(1.0F).a(e).a("lockedchest").a(true).g() : (new BlockLockedChest(95)).c(-1.0F).a(1.0F).a(e).a("lockedchest").g();
     public static final Block TRAP_DOOR = (new BlockTrapdoor(96, Material.WOOD)).c(3.0F).a(e).a("trapdoor").n().g();
     public static final List<Integer> leafDecayBlacklist = Arrays.asList(PoseidonConfig.getInstance().getTreeBlacklistIDs());
     public int textureId;

--- a/src/main/java/net/minecraft/server/BlockBed.java
+++ b/src/main/java/net/minecraft/server/BlockBed.java
@@ -2,13 +2,10 @@ package net.minecraft.server;
 
 import org.bukkit.event.entity.EntityDamageEvent;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockBed extends Block {
 
@@ -38,7 +35,7 @@ public class BlockBed extends Block {
             }
 
             // uberbukkit
-            if (!world.worldProvider.d() && PoseidonConfig.getInstance().getBoolean("version.mechanics.nether_bed_explode", true)) {
+            if (!world.worldProvider.d() && UberbukkitConfig.getInstance().getBoolean("mechanics.nether_bed_explode", true)) {
                 double d0 = (double) i + 0.5D;
                 double d1 = (double) j + 0.5D;
                 double d2 = (double) k + 0.5D;

--- a/src/main/java/net/minecraft/server/BlockFence.java
+++ b/src/main/java/net/minecraft/server/BlockFence.java
@@ -1,6 +1,7 @@
 package net.minecraft.server;
 
 import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockFence extends Block {
     private boolean modernFencingBounding = false;
@@ -13,7 +14,7 @@ public class BlockFence extends Block {
     public boolean canPlace(World world, int i, int j, int k) {
         return world.getTypeId(i, j - 1, k) == this.id ?
             // uberbukkit
-            PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_1_7_fence_placement", true) : (!world.getMaterial(i, j - 1, k).isBuildable() ? false : super.canPlace(world, i, j, k));
+            UberbukkitConfig.getInstance().getBoolean("mechanics.allow_1_7_fence_placement", true) : (!world.getMaterial(i, j - 1, k).isBuildable() ? false : super.canPlace(world, i, j, k));
     }
 
     public AxisAlignedBB e(World world, int i, int j, int k) {

--- a/src/main/java/net/minecraft/server/BlockFire.java
+++ b/src/main/java/net/minecraft/server/BlockFire.java
@@ -8,9 +8,8 @@ import org.bukkit.event.block.BlockIgniteEvent.IgniteCause;
 import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.material.MaterialData;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
-
 import uk.betacraft.uberbukkit.Uberbukkit;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 // CraftBukkit start
 // CraftBukkit end
@@ -35,7 +34,7 @@ public class BlockFire extends Block {
         this.a(Block.WOOL.id, 30, 60);
 
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.flammable_fences_stairs", true)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.flammable_fences_stairs", true)) {
             this.a(Block.FENCE.id, 5, 20);
             this.a(Block.WOOD_STAIRS.id, 5, 20);
         }
@@ -64,15 +63,15 @@ public class BlockFire extends Block {
 
     public int c() {
         // uberbukkit
-        return PoseidonConfig.getInstance().getBoolean("version.mechanics.pre_1_6_fire", false) ? 10 : 40;
+        return UberbukkitConfig.getInstance().getBoolean("mechanics.pre_1_6_fire", false) ? 10 : 40;
     }
 
     public void a(World world, int i, int j, int k, Random random) {
         boolean flag = world.getTypeId(i, j - 1, k) == Block.NETHERRACK.id;
-        boolean oldfire = PoseidonConfig.getInstance().getBoolean("version.mechanics.pre_1_6_fire", false);
+        boolean oldFire = UberbukkitConfig.getInstance().getBoolean("mechanics.pre_1_6_fire", false);
 
         // uberbukkit
-        if (!oldfire && !this.canPlace(world, i, j, k)) {
+        if (!oldFire && !this.canPlace(world, i, j, k)) {
             world.setTypeId(i, j, k, 0);
         }
 
@@ -82,7 +81,7 @@ public class BlockFire extends Block {
             int l = world.getData(i, j, k);
 
             // uberbukkit - fire
-            if (oldfire) {
+            if (oldFire) {
                 if (l < 15) {
                     world.setData(i, j, k, l + 1);
                     world.c(i, j, k, this.id, this.c());
@@ -112,7 +111,7 @@ public class BlockFire extends Block {
                 // CraftBukkit end
 
                 // uberbukkit
-                if (oldfire) {
+                if (oldFire) {
                     if (l % 2 == 0 && l > 2) {
                         this.a(world, i + 1, j, k, 300, random, l);
                         this.a(world, i - 1, j, k, 300, random, l);
@@ -221,7 +220,7 @@ public class BlockFire extends Block {
                     }
                 }
 
-                if (oldfire && l == 15) {
+                if (oldFire && l == 15) {
                     this.a(world, i + 1, j, k, 1, random, 0);
                     this.a(world, i - 1, j, k, 1, random, 0);
                     this.a(world, i, j - 1, k, 1, random, 0);
@@ -250,7 +249,7 @@ public class BlockFire extends Block {
             // CraftBukkit end
 
             // uberbukkit
-            if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.pre_1_6_fire", false)) {
+            if (!UberbukkitConfig.getInstance().getBoolean("mechanics.pre_1_6_fire", false)) {
                 if (random.nextInt(i1 + 10) < 5 && !world.s(i, j, k)) {
                     int k1 = i1 + random.nextInt(5) / 4;
 

--- a/src/main/java/net/minecraft/server/BlockLeaves.java
+++ b/src/main/java/net/minecraft/server/BlockLeaves.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import org.bukkit.event.block.LeavesDecayEvent;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.Random;
 
@@ -130,7 +130,7 @@ public class BlockLeaves extends BlockLeavesBase {
 
         int data = world.getData(i, j, k);
         // uberbukkit
-        if (data > 0 && !PoseidonConfig.getInstance().getBoolean("version.mechanics.drop_saplings_of_leaf_type", true)) {
+        if (data > 0 && !UberbukkitConfig.getInstance().getBoolean("mechanics.drop_saplings_of_leaf_type", true)) {
             data = 0;
         }
 
@@ -157,7 +157,7 @@ public class BlockLeaves extends BlockLeavesBase {
 
     protected int a_(int i) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.drop_saplings_of_leaf_type", true)) {
+        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.drop_saplings_of_leaf_type", true)) {
             return 0;
         } else {
             return i & 3;

--- a/src/main/java/net/minecraft/server/BlockLightStone.java
+++ b/src/main/java/net/minecraft/server/BlockLightStone.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockLightStone extends Block {
 
@@ -12,7 +12,7 @@ public class BlockLightStone extends Block {
 
     public int a(Random random) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.glowstone_pre1_6_6", false))
+        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.glowstone_pre1_6_6", false))
             return 2 + random.nextInt(3);
 
         return super.a(random);

--- a/src/main/java/net/minecraft/server/BlockLockedChest.java
+++ b/src/main/java/net/minecraft/server/BlockLockedChest.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockLockedChest extends Block {
 
@@ -17,7 +17,7 @@ public class BlockLockedChest extends Block {
 
     public boolean canPlace(World world, int i, int j, int k) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_steveco_chests", true)) {
+        if (!UberbukkitConfig.getInstance().getBoolean("worldgen.generate_steveco_chests", true)) {
             return true;
         }
 
@@ -48,7 +48,7 @@ public class BlockLockedChest extends Block {
 
     public void a(World world, int i, int j, int k, Random random) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_steveco_chests", true))
+        if (!UberbukkitConfig.getInstance().getBoolean("worldgen.generate_steveco_chests", true))
             world.setTypeId(i, j, k, 0);
     }
 }

--- a/src/main/java/net/minecraft/server/BlockMushroom.java
+++ b/src/main/java/net/minecraft/server/BlockMushroom.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import org.bukkit.event.block.BlockSpreadEvent;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.Random;
 
@@ -18,7 +18,7 @@ public class BlockMushroom extends BlockFlower {
 
     public void a(World world, int i, int j, int k, Random random) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.mushroom_spread", true)) return;
+        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.mushroom_spread", true)) return;
 
         if (random.nextInt(100) == 0) {
             int l = i + random.nextInt(3) - 1;

--- a/src/main/java/net/minecraft/server/BlockOre.java
+++ b/src/main/java/net/minecraft/server/BlockOre.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockOre extends Block {
 
@@ -16,7 +16,7 @@ public class BlockOre extends Block {
 
     public int a(Random random) {
         if (this.id == Block.LAPIS_ORE.id) {
-            if (PoseidonConfig.getInstance().getBoolean("version.mechanics.drop_lapis_as_b1_2", false)) {
+            if (UberbukkitConfig.getInstance().getBoolean("mechanics.drop_lapis_as_b1_2", false)) {
                 return 1;
             }
             return 4 + random.nextInt(5);

--- a/src/main/java/net/minecraft/server/BlockPumpkin.java
+++ b/src/main/java/net/minecraft/server/BlockPumpkin.java
@@ -1,7 +1,8 @@
 package net.minecraft.server;
 
 import org.bukkit.event.block.BlockRedstoneEvent;
-import com.legacyminecraft.poseidon.PoseidonConfig;
+
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockPumpkin extends Block {
 
@@ -46,7 +47,7 @@ public class BlockPumpkin extends Block {
 
     public void postPlace(World world, int i, int j, int k, EntityLiving entityliving) {
         double dt = 2.5D;
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.pre_b1_5_pumpkins", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.pre_b1_5_pumpkins", false)) {
             dt = 0.5D;
         }
         int l = MathHelper.floor((double) (entityliving.yaw * 4.0F / 360.0F) + dt) & 3;

--- a/src/main/java/net/minecraft/server/BlockSapling.java
+++ b/src/main/java/net/minecraft/server/BlockSapling.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import org.bukkit.BlockChangeDelegate;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.Random;
 
@@ -45,9 +45,9 @@ public class BlockSapling extends BlockFlower {
         BlockChangeWithNotify delegate = new BlockChangeWithNotify(world);
 
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.biomes.generate_spruces", true) && l == 1) {
+        if (l == 1 && UberbukkitConfig.getInstance().getBoolean("worldgen.biomes.generate_spruces", true)) {
             grownTree = new WorldGenTaiga2().generate(delegate, random, i, j, k);
-        } else if (PoseidonConfig.getInstance().getBoolean("version.worldgen.biomes.generate_birches", true) && l == 2) {
+        } else if (l == 2 && UberbukkitConfig.getInstance().getBoolean("worldgen.biomes.generate_birches", true)) {
             grownTree = new WorldGenForest().generate(delegate, random, i, j, k);
         } else {
             if (random.nextInt(10) == 0) {
@@ -65,7 +65,7 @@ public class BlockSapling extends BlockFlower {
 
     protected int a_(int i) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.drop_saplings_of_leaf_type", true)) {
+        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.drop_saplings_of_leaf_type", true)) {
             return 0;
         } else {
             return i & 3;

--- a/src/main/java/net/minecraft/server/BlockTNT.java
+++ b/src/main/java/net/minecraft/server/BlockTNT.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockTNT extends Block {
 
@@ -57,7 +57,7 @@ public class BlockTNT extends Block {
 
     public void b(World world, int i, int j, int k, EntityHuman entityhuman) {
         // uberbukkit
-        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.tnt_require_lighter", true)) {
+        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.tnt_require_lighter", true)) {
             world.setRawData(i, j, k, 1);
         }
 

--- a/src/main/java/net/minecraft/server/BlockTorch.java
+++ b/src/main/java/net/minecraft/server/BlockTorch.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class BlockTorch extends Block {
 
@@ -26,7 +26,7 @@ public class BlockTorch extends Block {
     private boolean g(World world, int i, int j, int k) {
         return world.e(i, j, k) ||
             // uberbukkit
-            (PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_1_7_fence_placement", true) && world.getTypeId(i, j, k) == Block.FENCE.id);
+            (UberbukkitConfig.getInstance().getBoolean("mechanics.allow_1_7_fence_placement", true) && world.getTypeId(i, j, k) == Block.FENCE.id);
     }
 
     public boolean canPlace(World world, int i, int j, int k) {

--- a/src/main/java/net/minecraft/server/ChunkCache.java
+++ b/src/main/java/net/minecraft/server/ChunkCache.java
@@ -1,6 +1,6 @@
 package net.minecraft.server;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class ChunkCache implements IBlockAccess {
 
@@ -77,7 +77,7 @@ public class ChunkCache implements IBlockAccess {
     }
 
     public boolean e(int i, int j, int k) {
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.pre_b1_6_block_opacity", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.pre_b1_6_block_opacity", false)) {
             return this.p(i, j, k);
         }
         Block block = Block.byId[this.getTypeId(i, j, k)];

--- a/src/main/java/net/minecraft/server/ChunkProviderGenerate.java
+++ b/src/main/java/net/minecraft/server/ChunkProviderGenerate.java
@@ -1,9 +1,8 @@
 package net.minecraft.server;
 
-import java.util.Calendar;
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class ChunkProviderGenerate implements IChunkProvider {
 
@@ -182,7 +181,7 @@ public class ChunkProviderGenerate implements IChunkProvider {
                                 --j1;
                                 abyte[l1] = b2;
                                 // uberbukkit
-                                if (PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_sandstone", true) && j1 == 0 && b2 == Block.SAND.id) {
+                                if (UberbukkitConfig.getInstance().getBoolean("worldgen.generate_sandstone", true) && j1 == 0 && b2 == Block.SAND.id) {
                                     j1 = this.j.nextInt(4);
                                     b2 = (byte) Block.SANDSTONE.id;
                                 }
@@ -423,7 +422,7 @@ public class ChunkProviderGenerate implements IChunkProvider {
         }
 
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_lapis_ores", true)) {
+        if (UberbukkitConfig.getInstance().getBoolean("worldgen.generate_lapis_ores", true)) {
             for (k1 = 0; k1 < 1; ++k1) {
                 l1 = k + this.j.nextInt(16);
                 i2 = this.j.nextInt(16) + this.j.nextInt(16);
@@ -469,7 +468,7 @@ public class ChunkProviderGenerate implements IChunkProvider {
 
         // uberbukkit
         Object object = biomebase.a(this.j);
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.pre_b1_2_tree_generation", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("worldgen.pre_b1_2_tree_generation", false)) {
             object = new WorldGenTrees();
             if (this.j.nextInt(10) == 0) {
                 object = new WorldGenBigTree();
@@ -546,7 +545,7 @@ public class ChunkProviderGenerate implements IChunkProvider {
         int k3;
 
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_tallgrass", true)) {
+        if (UberbukkitConfig.getInstance().getBoolean("worldgen.generate_tallgrass", true)) {
             for (k2 = 0; k2 < b1; ++k2) {
                 byte b2 = 1;
 
@@ -567,7 +566,7 @@ public class ChunkProviderGenerate implements IChunkProvider {
         }
 
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_tallgrass", true)) {
+        if (UberbukkitConfig.getInstance().getBoolean("worldgen.generate_tallgrass", true)) {
             for (k2 = 0; k2 < b1; ++k2) {
                 i3 = k + this.j.nextInt(16) + 8;
                 l2 = this.j.nextInt(128);
@@ -653,7 +652,7 @@ public class ChunkProviderGenerate implements IChunkProvider {
         }
 
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.generate_steveco_chests", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("worldgen.generate_steveco_chests", false)) {
             k2 = k + this.j.nextInt(16) + 8;
             l2 = this.j.nextInt(128);
             i3 = l + this.j.nextInt(16) + 8;

--- a/src/main/java/net/minecraft/server/CraftingManager.java
+++ b/src/main/java/net/minecraft/server/CraftingManager.java
@@ -5,9 +5,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
-
 import uk.betacraft.uberbukkit.Uberbukkit;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class CraftingManager {
 
@@ -61,19 +60,19 @@ public class CraftingManager {
             this.registerShapedRecipe(new ItemStack(Block.PISTON_STICKY, 1), new Object[] { "S", "P", Character.valueOf('S'), Item.SLIME_BALL, Character.valueOf('P'), Block.PISTON });
         }
 
-        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.glowstone_pre1_6_6", false)) {
+        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.glowstone_pre1_6_6", false)) {
             this.registerShapedRecipe(new ItemStack(Block.GLOWSTONE, 1), new Object[] { "##", "##", Character.valueOf('#'), Item.GLOWSTONE_DUST });
         } else {
             this.registerShapedRecipe(new ItemStack(Block.GLOWSTONE, 1), new Object[] { "###", "###", "###", Character.valueOf('#'), Item.GLOWSTONE_DUST });
         }
 
-        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.wool_recipe_pre1_6_6", false)) {
+        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.wool_recipe_pre1_6_6", false)) {
             this.registerShapedRecipe(new ItemStack(Block.WOOL, 1), new Object[] { "##", "##", Character.valueOf('#'), Item.STRING });
         } else {
             this.registerShapedRecipe(new ItemStack(Block.WOOL, 1), new Object[] { "###", "###", "###", Character.valueOf('#'), Item.STRING });
         }
 
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.old_slab_recipe", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.old_slab_recipe", false)) {
             this.registerShapedRecipe(new ItemStack(Block.STEP, 3, 0), new Object[] { "###", Character.valueOf('#'), Block.COBBLESTONE });
             if (Uberbukkit.getTargetPVN() >= 9) {
                 this.registerShapedRecipe(new ItemStack(Block.STEP, 3, 1), new Object[] { "###", Character.valueOf('#'), Block.SANDSTONE });
@@ -100,7 +99,7 @@ public class CraftingManager {
 
         // uberbukkit
         ItemStack ladder = new ItemStack(Block.LADDER, 2);
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_ladder_gap", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.allow_ladder_gap", false)) {
             ladder = new ItemStack(Block.LADDER, 1);
         }
         this.registerShapedRecipe(ladder, new Object[] { "# #", "###", "# #", Character.valueOf('#'), Item.STICK });

--- a/src/main/java/net/minecraft/server/Entity.java
+++ b/src/main/java/net/minecraft/server/Entity.java
@@ -12,7 +12,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.List;
 import java.util.Random;
@@ -39,7 +39,7 @@ public abstract class Entity {
     };
     // Poseidon end
     // uberbukkit
-    private static boolean trampleFarmlandAboveFence = PoseidonConfig.getInstance().getBoolean("version.mechanics.trample_farmland_above_fence", false);
+    private static final boolean trampleFarmlandAboveFence = UberbukkitConfig.getInstance().getBoolean("mechanics.trample_farmland_above_fence", false);
 
     private static int entityCount = 0;
     public int id;

--- a/src/main/java/net/minecraft/server/EntityArrow.java
+++ b/src/main/java/net/minecraft/server/EntityArrow.java
@@ -7,7 +7,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.List;
 
@@ -298,7 +298,7 @@ public class EntityArrow extends Entity {
         if (!this.world.isStatic) {
 
             // uberbukkit
-            if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.arrows_pickup_by_others", true)) {
+            if (!UberbukkitConfig.getInstance().getBoolean("mechanics.arrows_pickup_by_others", true)) {
                 if (this.shooter != entityhuman) {
                     return;
                 }

--- a/src/main/java/net/minecraft/server/EntityBoat.java
+++ b/src/main/java/net/minecraft/server/EntityBoat.java
@@ -4,7 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.vehicle.*;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.List;
 
@@ -123,7 +123,7 @@ public class EntityBoat extends Entity {
                 }
 
                 // uberbukkit - drop boat on damage, not planks & sticks
-                if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.boats.drop_boat_not_wood", false)) {
+                if (!UberbukkitConfig.getInstance().getBoolean("mechanics.boats.drop_boat_not_wood", false)) {
                     int j;
 
                     for (j = 0; j < 3; ++j) {
@@ -291,11 +291,11 @@ public class EntityBoat extends Entity {
             if (this.positionChanged && d4 > 0.15D) {
                 if (!this.world.isStatic) {
 
-                    if (PoseidonConfig.getInstance().getBoolean("version.mechanics.boat.break_boat_on_collision", true)) {
+                    if (UberbukkitConfig.getInstance().getBoolean("mechanics.boat.break_boat_on_collision", true)) {
                         this.die();
 
                         // uberbukkit - drop boat on damage, not planks & sticks
-                        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.boats.drop_boat_not_wood", false)) {
+                        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.boats.drop_boat_not_wood", false)) {
                             int k;
 
                             for (k = 0; k < 3; ++k) {

--- a/src/main/java/net/minecraft/server/EntityLiving.java
+++ b/src/main/java/net/minecraft/server/EntityLiving.java
@@ -9,7 +9,7 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.List;
 
@@ -620,7 +620,7 @@ public abstract class EntityLiving extends Entity {
 
         return this.world.getTypeId(i, j, k) == Block.LADDER.id ||
             // uberbukkit
-            (PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_ladder_gap", false) && this.world.getTypeId(i, j + 1, k) == Block.LADDER.id);
+            (UberbukkitConfig.getInstance().getBoolean("mechanics.allow_ladder_gap", false) && this.world.getTypeId(i, j + 1, k) == Block.LADDER.id);
     }
 
     public void b(NBTTagCompound nbttagcompound) {

--- a/src/main/java/net/minecraft/server/EntityMinecart.java
+++ b/src/main/java/net/minecraft/server/EntityMinecart.java
@@ -4,7 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.vehicle.*;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.List;
 
@@ -754,7 +754,7 @@ public class EntityMinecart extends Entity implements IInventory {
                     d1 *= 0.5D;
                     if (entity instanceof EntityMinecart) {
                         // uberbukkit
-                        if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_minecart_boosters", false)) {
+                        if (!UberbukkitConfig.getInstance().getBoolean("mechanics.allow_minecart_boosters", false)) {
                             double d4 = entity.locX - this.locX;
                             double d5 = entity.locZ - this.locZ;
                             double d6 = d4 * entity.motZ + d5 * entity.lastX;

--- a/src/main/java/net/minecraft/server/EntityPig.java
+++ b/src/main/java/net/minecraft/server/EntityPig.java
@@ -4,9 +4,8 @@ package net.minecraft.server;
 
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
-
 import org.bukkit.event.entity.PigZapEvent;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 // CraftBukkit end
 
 public class EntityPig extends EntityAnimal {
@@ -54,7 +53,7 @@ public class EntityPig extends EntityAnimal {
 
     protected int j() {
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.burning_pig_drop_cooked_meat", true) && this.fireTicks > 0) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.burning_pig_drop_cooked_meat", true) && this.fireTicks > 0) {
             return Item.GRILLED_PORK.id;
         } else {
             return Item.PORK.id;

--- a/src/main/java/net/minecraft/server/EntityPlayer.java
+++ b/src/main/java/net/minecraft/server/EntityPlayer.java
@@ -21,6 +21,7 @@ import com.legacyminecraft.poseidon.event.PlayerDeathEvent;
 import com.projectposeidon.api.PoseidonUUID;
 
 import me.devcody.uberbukkit.util.math.Vec3i;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 import uk.betacraft.uberbukkit.alpha.inventory.ProcessPacket5;
 import uk.betacraft.uberbukkit.packet.Packet62Sound;
 import uk.betacraft.uberbukkit.protocol.Protocol;
@@ -437,7 +438,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
             entitytracker.a(this, packet17);
 
             // uberbukkit - beds (b1.3 - b1.6.4)
-            if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.beds_pre_b1_6_5", false))
+            if (!UberbukkitConfig.getInstance().getBoolean("mechanics.beds_pre_b1_6_5", false))
                 this.netServerHandler.a(this.locX, this.locY, this.locZ, this.yaw, this.pitch);
 
             this.netServerHandler.sendPacket(packet17);
@@ -641,7 +642,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
 
     public void a(String s) {
         // uberbukkit - fix for multiple bed alerts (b1.3 - b1.6.4)
-        if (this.netServerHandler.networkManager.pvn <= 11 || PoseidonConfig.getInstance().getBoolean("version.mechanics.beds_pre_b1_6_5", false))
+        if (this.netServerHandler.networkManager.pvn <= 11 || UberbukkitConfig.getInstance().getBoolean("mechanics.beds_pre_b1_6_5", false))
             return;
 
         StatisticStorage statisticstorage = StatisticStorage.a();

--- a/src/main/java/net/minecraft/server/EntitySheep.java
+++ b/src/main/java/net/minecraft/server/EntitySheep.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class EntitySheep extends EntityAnimal {
 
@@ -21,7 +21,7 @@ public class EntitySheep extends EntityAnimal {
 
     public boolean damageEntity(Entity entity, int i) {
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.sheep_drop_wool_on_punch", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.sheep_drop_wool_on_punch", false)) {
             if (!this.world.isStatic && !this.isSheared() && entity instanceof EntityLiving) {
                 this.setSheared(true);
                 int j = 1 + this.random.nextInt(3);
@@ -136,8 +136,8 @@ public class EntitySheep extends EntityAnimal {
         int i = random.nextInt(100);
 
         // uberbukkit
-        boolean spawn_black = PoseidonConfig.getInstance().getBoolean("version.mechanics.spawn_sheep_with_shades_of_black", true);
-        boolean spawn_brown_pink = PoseidonConfig.getInstance().getBoolean("version.mechanics.spawn_brown_and_pink_sheep", true);
+        boolean spawn_black = UberbukkitConfig.getInstance().getBoolean("mechanics.spawn_sheep_with_shades_of_black", true);
+        boolean spawn_brown_pink = UberbukkitConfig.getInstance().getBoolean("mechanics.spawn_brown_and_pink_sheep", true);
 
         if (i < 5 && spawn_black) {
             return 15;

--- a/src/main/java/net/minecraft/server/EntitySpider.java
+++ b/src/main/java/net/minecraft/server/EntitySpider.java
@@ -7,7 +7,7 @@ import org.bukkit.event.entity.EntityTargetEvent;
 // CraftBukkit end
 
 //uberbukkit start
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 //uberbukkit end
 
 public class EntitySpider extends EntityMonster {
@@ -24,7 +24,7 @@ public class EntitySpider extends EntityMonster {
     }
 
     protected boolean n() {
-        return PoseidonConfig.getInstance().getBoolean("version.mechanics.spiders_trample_crops", false);
+        return UberbukkitConfig.getInstance().getBoolean("mechanics.spiders_trample_crops", false);
     }
 
     protected Entity findTarget() {
@@ -98,6 +98,6 @@ public class EntitySpider extends EntityMonster {
     }
 
     public boolean p() {
-        return PoseidonConfig.getInstance().getBoolean("version.mechanics.spiders_climb_walls", true) ? this.positionChanged : super.p();
+        return UberbukkitConfig.getInstance().getBoolean("mechanics.spiders_climb_walls", true) ? this.positionChanged : super.p();
     }
 }

--- a/src/main/java/net/minecraft/server/EntitySquid.java
+++ b/src/main/java/net/minecraft/server/EntitySquid.java
@@ -6,7 +6,7 @@ import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class EntitySquid extends EntityWaterAnimal {
 
@@ -83,7 +83,7 @@ public class EntitySquid extends EntityWaterAnimal {
 
     public boolean a(EntityHuman entityhuman) {
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_milking_squids", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.allow_milking_squids", false)) {
             ItemStack itemstack = entityhuman.inventory.getItemInHand();
 
             if (itemstack != null && itemstack.id == Item.BUCKET.id) {

--- a/src/main/java/net/minecraft/server/ItemBlock.java
+++ b/src/main/java/net/minecraft/server/ItemBlock.java
@@ -7,7 +7,7 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.block.BlockPlaceEvent;
 // CraftBukkit end
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class ItemBlock extends Item {
 
@@ -52,7 +52,7 @@ public class ItemBlock extends Item {
 
         if (itemstack.count == 0) {
             return false;
-        } else if (!PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_blocks_at_y_127", false) && j == 127 && Block.byId[this.id].material.isBuildable()) {
+        } else if (!UberbukkitConfig.getInstance().getBoolean("mechanics.allow_blocks_at_y_127", false) && j == 127 && Block.byId[this.id].material.isBuildable()) {
             return false;
         } else if (world.a(this.id, i, j, k, false, l)) {
             Block block = Block.byId[this.id];

--- a/src/main/java/net/minecraft/server/ItemDye.java
+++ b/src/main/java/net/minecraft/server/ItemDye.java
@@ -1,6 +1,6 @@
 package net.minecraft.server;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class ItemDye extends Item {
 
@@ -35,7 +35,7 @@ public class ItemDye extends Item {
                 return true;
             }
 
-            if (i1 == Block.GRASS.id && PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_bone_meal_on_grass", true)) {
+            if (i1 == Block.GRASS.id && UberbukkitConfig.getInstance().getBoolean("mechanics.allow_bone_meal_on_grass", true)) {
                 if (!world.isStatic) {
                     --itemstack.count;
 
@@ -56,7 +56,7 @@ public class ItemDye extends Item {
 
                         if (world.getTypeId(k1, l1, i2) == 0) {
                             // uberbukkit
-                            if (PoseidonConfig.getInstance().getBoolean("version.mechanics.allow_grow_tallgrass", true) && b.nextInt(10) != 0) {
+                            if (UberbukkitConfig.getInstance().getBoolean("mechanics.allow_grow_tallgrass", true) && b.nextInt(10) != 0) {
                                 world.setTypeIdAndData(k1, l1, i2, Block.LONG_GRASS.id, 1);
                             } else if (b.nextInt(3) != 0) {
                                 world.setTypeId(k1, l1, i2, Block.YELLOW_FLOWER.id);

--- a/src/main/java/net/minecraft/server/ItemHoe.java
+++ b/src/main/java/net/minecraft/server/ItemHoe.java
@@ -7,7 +7,7 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.block.BlockPlaceEvent;
 // CraftBukkit end
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class ItemHoe extends Item {
 
@@ -46,7 +46,7 @@ public class ItemHoe extends Item {
                 itemstack.damage(1, entityhuman);
 
                 // uberbukkit
-                if (PoseidonConfig.getInstance().getBoolean("version.mechanics.tile_grass_drop_seeds", false)) {
+                if (UberbukkitConfig.getInstance().getBoolean("mechanics.tile_grass_drop_seeds", false)) {
                     if (world.random.nextInt(8) == 0 && i1 == Block.GRASS.id) {
                         byte b0 = 1;
 

--- a/src/main/java/net/minecraft/server/ItemSeeds.java
+++ b/src/main/java/net/minecraft/server/ItemSeeds.java
@@ -7,7 +7,7 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.block.BlockPlaceEvent;
 // CraftBukkit end
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class ItemSeeds extends Item {
 
@@ -27,7 +27,7 @@ public class ItemSeeds extends Item {
             // uberbukkit start
             boolean isEmptyFlag = world.isEmpty(i, j + 1, k);
 
-            if (PoseidonConfig.getInstance().getBoolean("version.mechanics.seeds_replace_blocks", false)) {
+            if (UberbukkitConfig.getInstance().getBoolean("mechanics.seeds_replace_blocks", false)) {
                 isEmptyFlag = true;
             }
 

--- a/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -19,6 +19,7 @@ import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.event.world.WorldSaveEvent;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.plugin.PluginLoadOrder;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -113,7 +114,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
             net.minecraft.server.ModLoader.Init(this);
         }
 
-        log.info("Starting minecraft server... Accepting PVNs: " + String.join(", ", PoseidonConfig.getInstance().getString("version.allow_join.protocol", "14").split(",")));
+        log.info("Starting minecraft server... Accepting PVNs: " + String.join(", ", UberbukkitConfig.getInstance().getString("client.allowed_protocols.value", "14").split(",")));
         if (Runtime.getRuntime().maxMemory() / 1024L / 1024L < 512L) {
             log.warning("**** NOT ENOUGH RAM!");
             log.warning("To start the server with more ram, launch it as \"java -Xmx1024M -Xms1024M -jar minecraft_server.jar\"");

--- a/src/main/java/net/minecraft/server/World.java
+++ b/src/main/java/net/minecraft/server/World.java
@@ -30,9 +30,8 @@ import org.bukkit.event.weather.ThunderChangeEvent;
 import org.bukkit.event.weather.WeatherChangeEvent;
 import org.bukkit.generator.ChunkGenerator;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
-
 import uk.betacraft.uberbukkit.Uberbukkit;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 // CraftBukkit start
 // CraftBukkit end
@@ -40,7 +39,7 @@ import uk.betacraft.uberbukkit.Uberbukkit;
 public class World implements IBlockAccess {
 
     // uberbukkit
-    private static boolean pre1_5_placement_rules = PoseidonConfig.getInstance().getBoolean("version.mechanics.pre_b1_5_block_placement_rules", false);
+    private static final boolean pre1_5_placement_rules = UberbukkitConfig.getInstance().getBoolean("mechanics.pre_b1_5_block_placement_rules", false);
 
     public boolean a = false;
     private List C = new ArrayList();
@@ -1633,7 +1632,7 @@ public class World implements IBlockAccess {
     }
 
     public boolean e(int i, int j, int k) {
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.pre_b1_6_block_opacity", false)) {
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.pre_b1_6_block_opacity", false)) {
             return this.p(i, j, k);
         }
         Block block = Block.byId[this.getTypeId(i, j, k)];
@@ -1993,7 +1992,7 @@ public class World implements IBlockAccess {
                     }
 
                     // uberbukkit
-                    boolean blocked = PoseidonConfig.getInstance().getBoolean("version.mechanics.ice_generate_only_when_snowing", false) && !this.v();
+                    boolean blocked = UberbukkitConfig.getInstance().getBoolean("mechanics.ice_generate_only_when_snowing", false) && !this.v();
 
                     // CraftBukkit start
                     if (!blocked && l1 == Block.STATIONARY_WATER.id && chunk.getData(l, k1 - 1, j1) == 0) {
@@ -2456,7 +2455,7 @@ public class World implements IBlockAccess {
 
     public boolean v() {
         // uberbukkit
-        if (PoseidonConfig.getInstance().getBoolean("version.mechanics.do_weather", true))
+        if (UberbukkitConfig.getInstance().getBoolean("mechanics.do_weather", true))
             return (double) this.d(1.0F) > 0.2D;
 
         return false;

--- a/src/main/java/net/minecraft/server/WorldGenDungeons.java
+++ b/src/main/java/net/minecraft/server/WorldGenDungeons.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class WorldGenDungeons extends WorldGenerator {
 
@@ -159,7 +159,7 @@ public class WorldGenDungeons extends WorldGenerator {
             }
             case 10: {
                 // uberbukkit
-                if (PoseidonConfig.getInstance().getBoolean("version.worldgen.cocoabeans_loot", true)) {
+                if (UberbukkitConfig.getInstance().getBoolean("worldgen.cocoabeans_loot", true)) {
                     return new ItemStack(Item.INK_SACK, 1, 3);
                 }
             }

--- a/src/main/java/net/minecraft/server/WorldGenMinable.java
+++ b/src/main/java/net/minecraft/server/WorldGenMinable.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.Random;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class WorldGenMinable extends WorldGenerator {
 
@@ -15,8 +15,8 @@ public class WorldGenMinable extends WorldGenerator {
     }
 
     public boolean a(World world, Random random, int i, int j, int k) {
-        if (PoseidonConfig.getInstance().getBoolean("version.worldgen.ores." + world.worldData.name + ".custom_seed", false)) {
-            String text = PoseidonConfig.getInstance().getString("version.worldgen.ores." + world.worldData.name + ".seed");
+        if (UberbukkitConfig.getInstance().getBoolean("worldgen.ores." + world.worldData.name + ".custom_seed", false)) {
+            String text = UberbukkitConfig.getInstance().getString("worldgen.ores." + world.worldData.name + ".seed");
             long seed = 0L;
             if (text != null) {
                 seed = Long.parseLong(text);
@@ -41,7 +41,7 @@ public class WorldGenMinable extends WorldGenerator {
             double d11 = (double) (MathHelper.sin((float) l * 3.1415927F / (float) this.b) + 1.0F) * d9 + 1.0D;
 
             // uberbukkit
-            if (PoseidonConfig.getInstance().getBoolean("version.worldgen.pre_b1_2_ore_generation", false)) {
+            if (UberbukkitConfig.getInstance().getBoolean("worldgen.pre_b1_2_ore_generation", false)) {
                 for (int i1 = (int) (d6 - d10 / 2.0D); i1 <= (int) (d6 + d10 / 2.0D); ++i1) {
                     for (int j1 = (int) (d7 - d11 / 2.0D); j1 <= (int) (d7 + d11 / 2.0D); ++j1) {
                         for (int k1 = (int) (d8 - d10 / 2.0D); k1 <= (int) (d8 + d10 / 2.0D); ++k1) {

--- a/src/main/java/net/minecraft/server/WorldServer.java
+++ b/src/main/java/net/minecraft/server/WorldServer.java
@@ -6,7 +6,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.weather.LightningStrikeEvent;
 import org.bukkit.generator.ChunkGenerator;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -121,7 +121,7 @@ public class WorldServer extends World implements BlockChangeDelegate {
         this.getServer().getPluginManager().callEvent(lightning);
 
         // uberbukkit
-        if (lightning.isCancelled() || !PoseidonConfig.getInstance().getBoolean("version.mechanics.do_weather", true)) {
+        if (lightning.isCancelled() || !UberbukkitConfig.getInstance().getBoolean("mechanics.do_weather", true)) {
             return false;
         }
 

--- a/src/main/java/org/bukkit/craftbukkit/util/LongHashtable.java
+++ b/src/main/java/org/bukkit/craftbukkit/util/LongHashtable.java
@@ -4,10 +4,10 @@ import static org.bukkit.craftbukkit.util.Java15Compat.Arrays_copyOf;
 
 import java.util.ArrayList;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
-
 import net.minecraft.server.Chunk;
 import net.minecraft.server.MinecraftServer;
+
+import uk.betacraft.uberbukkit.UberbukkitConfig;
 
 public class LongHashtable<V> extends LongHash {
     Object[][][] values = new Object[256][][];
@@ -33,7 +33,7 @@ public class LongHashtable<V> extends LongHash {
             if (msw != c.x || lsw != c.z) {
                 MinecraftServer.log.info("Chunk (" + c.x + ", " + c.z + ") stored at  (" + msw + ", " + lsw + ")");
 
-                if (PoseidonConfig.getInstance().getBoolean("version.experimental.force_fix_chunk_coords_corruption", false)) {
+                if (UberbukkitConfig.getInstance().getBoolean("experimental.force_fix_chunk_coords_corruption", false)) {
                     c.x = msw;
                     c.z = lsw;
                 } else {

--- a/src/main/java/uk/betacraft/uberbukkit/Uberbukkit.java
+++ b/src/main/java/uk/betacraft/uberbukkit/Uberbukkit.java
@@ -1,6 +1,5 @@
 package uk.betacraft.uberbukkit;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import uk.betacraft.uberbukkit.protocol.Protocol;
@@ -17,7 +16,7 @@ public class Uberbukkit {
     public static int getTargetPVN() {
         if (pvn != null) return pvn;
 
-        String pvnstr = PoseidonConfig.getInstance().getString("version.allow_join.protocol", "14");
+        String pvnstr = UberbukkitConfig.getInstance().getString("client.allowed_protocols.value", "14");
 
         // separate target version from other allowed PVNs
         int commaIndex = pvnstr.indexOf(",");
@@ -40,7 +39,7 @@ public class Uberbukkit {
     public static List<Integer> getAllowedPVNs() {
         if (pvns != null) return pvns;
 
-        String[] pvnstrs = PoseidonConfig.getInstance().getString("version.allow_join.protocol", "14").split(",");
+        String[] pvnstrs = UberbukkitConfig.getInstance().getString("client.allowed_protocols.value", "14").split(",");
 
         pvns = new LinkedList<>();
 

--- a/src/main/java/uk/betacraft/uberbukkit/UberbukkitConfig.java
+++ b/src/main/java/uk/betacraft/uberbukkit/UberbukkitConfig.java
@@ -1,0 +1,131 @@
+package uk.betacraft.uberbukkit;
+
+import com.legacyminecraft.poseidon.PoseidonConfig;
+import org.bukkit.util.config.Configuration;
+
+import java.io.File;
+import java.util.List;
+
+public class UberbukkitConfig extends Configuration {
+    private static UberbukkitConfig singleton;
+    private static final int CONFIG_VERSION = 1;
+
+    public synchronized static UberbukkitConfig getInstance() {
+        if (singleton == null) {
+            singleton = new UberbukkitConfig();
+        }
+        return singleton;
+    }
+
+    public UberbukkitConfig() {
+        super(new File("uberbukkit.yml"));
+
+        this.init();
+    }
+
+    public void init() {
+        this.load();
+        this.writeDefaults();
+        this.save();
+    }
+
+    private void migrateByKey(String oldKey, String newKey) {
+        List<String> versionKeys = PoseidonConfig.getInstance().getKeys(oldKey);
+        if (versionKeys == null)
+            return;
+
+        for (String key : versionKeys) {
+            Object property = PoseidonConfig.getInstance().getProperty(oldKey + "." + key);
+            if (property != null) {
+                // move the entry to uberbukkit.yml
+                this.setProperty(newKey + "." + key, property);
+                // remove the entry from poseidon.yml
+                PoseidonConfig.getInstance().removeProperty(oldKey + "." + key);
+            }
+        }
+    }
+
+    private void migrateFromPoseidonConfig() {
+        migrateByKey("version.mechanics", "mechanics");
+        migrateByKey("version.mechanics.boats", "mechanics.boats");
+        migrateByKey("version.worldgen", "worldgen");
+        migrateByKey("version.worldgen.biomes", "worldgen.biomes");
+        migrateByKey("version.worldgen.ores.world", "worldgen.ores.world");
+        migrateByKey("version.experimental", "experimental");
+
+        String pvns = PoseidonConfig.getInstance().getString("version.allow_join.protocol");
+        this.setProperty("client.allowed_protocols.value", pvns);
+    }
+
+    private void writeDefaults() {
+        if (this.getString("config-version") == null || Integer.valueOf(this.getString("config-version")) < CONFIG_VERSION) {
+            System.out.println("[Uberbukkit] Converting from config version " + (this.getString("config-version") == null ? "0" : this.getString("config-version")) + " to " + CONFIG_VERSION);
+            migrateFromPoseidonConfig();
+            this.setProperty("config-version", CONFIG_VERSION);
+        }
+
+        writeDefault("worldgen.cocoabeans_loot", true);
+        writeDefault("worldgen.pre_b1_2_ore_generation", false);
+        writeDefault("worldgen.pre_b1_2_tree_generation", false);
+        writeDefault("worldgen.generate_sandstone", true);
+        writeDefault("worldgen.biomes.generate_spruces", true);
+        writeDefault("worldgen.biomes.generate_birches", true);
+        writeDefault("worldgen.generate_steveco_chests", false);
+        writeDefault("worldgen.generate_lapis_ores", true);
+        writeDefault("worldgen.generate_tallgrass", true);
+        writeDefault("worldgen.ores.world.custom_seed", false);
+        writeDefault("worldgen.ores.world.seed", 0L);
+
+        writeDefault("mechanics.tile_grass_drop_seeds", false);
+        writeDefault("mechanics.flammable_fences_stairs", true);
+        writeDefault("mechanics.glowstone_pre1_6_6", false);
+        writeDefault("mechanics.wool_recipe_pre1_6_6", false);
+        writeDefault("mechanics.allow_grow_tallgrass", true);
+        writeDefault("mechanics.allow_1_7_fence_placement", true);
+        writeDefault("mechanics.tnt_require_lighter", true);
+        writeDefault("mechanics.sheep_drop_wool_on_punch", false);
+        writeDefault("mechanics.mushroom_spread", true);
+        writeDefault("mechanics.ice_generate_only_when_snowing", false);
+        writeDefault("mechanics.pre_1_6_fire", false);
+        writeDefault("mechanics.nether_bed_explode", true);
+        writeDefault("mechanics.arrows_pickup_by_others", true);
+        writeDefault("mechanics.allow_minecart_boosters", false);
+        writeDefault("mechanics.spawn_squids", true);
+        writeDefault("mechanics.spawn_wolves", true);
+        writeDefault("mechanics.spawn_slimes", true);
+        writeDefault("mechanics.do_weather", true);
+        writeDefault("mechanics.allow_ladder_gap", false);
+        writeDefault("mechanics.old_slab_recipe", false);
+        writeDefault("mechanics.burning_pig_drop_cooked_meat", true);
+        writeDefault("mechanics.spawn_sheep_with_shades_of_black", true);
+        writeDefault("mechanics.spawn_brown_and_pink_sheep", true);
+        writeDefault("mechanics.drop_saplings_of_leaf_type", true);
+        writeDefault("mechanics.spiders_trample_crops", false);
+        writeDefault("mechanics.spiders_climb_walls", true);
+        writeDefault("mechanics.allow_blocks_at_y_127", false);
+        writeDefault("mechanics.drop_lapis_as_b1_2", false);
+        writeDefault("mechanics.allow_milking_squids", false);
+        writeDefault("mechanics.pre_b1_6_block_opacity", false);
+        writeDefault("mechanics.pre_b1_5_pumpkins", false);
+        writeDefault("mechanics.allow_bone_meal_on_grass", true);
+        writeDefault("mechanics.beds_pre_b1_6_5", false);
+        writeDefault("mechanics.beds_set_spawnpoint", true);
+        writeDefault("mechanics.pre_b1_5_block_placement_rules", false);
+        writeDefault("mechanics.trample_farmland_above_fence", false);
+        writeDefault("mechanics.seeds_replace_blocks", false);
+        writeDefault("mechanics.boats.drop_boat_not_wood", false);
+        writeDefault("mechanics.boats.break_boat_on_collision", true);
+
+        writeDefault("experimental.force_fix_chunk_coords_corruption", false);
+
+        writeDefault("client.allowed_protocols.value", "14");
+        writeDefault("client.allowed_protocols.info1", "Specify client versions to accept (separated by commas - first PVN is treated as target PVN of the server)");
+        writeDefault("client.allowed_protocols.info2", "6 - a1.2.3_05 to a1.2.6; 7 - b1.0 to b1.1_02; 8 - b1.2 to b1.2_02; 9 - b1.3(_01); 10 - b1.4(_01); 11 - b1.5(_01); 12 - b1.6_test_build_3; 13 - b1.6 to b1.6.6, 14 - b1.7 to b1.7.3");
+    }
+
+    private void writeDefault(String key, Object defaultValue) {
+        if (this.getProperty(key) == null) {
+            this.setProperty(key, defaultValue);
+        }
+    }
+}


### PR DESCRIPTION
Automatic migration included.

Key `version` is dropped, and its subkeys are elevated in hierarchy.

`version.allow_join.protocol` changed to `client.allowed_protocols.value`