### PR TITLE
fix: recursive call for CraftServer.getGameVersion()

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -63,7 +63,7 @@ public final class CraftServer implements Server {
     private final String serverVersion = "1.1.10";
     private final String releaseType = "DEVELOPMENT";
     private final String protocolVersion = "1.7.3";
-    private final String GameVersion = "b1.7.3";
+    private final String gameVersion = "b1.7.3";
     private final ServicesManager servicesManager = new SimpleServicesManager();
     private final BukkitScheduler scheduler = new CraftScheduler(this);
     private final SimpleCommandMap commandMap = new SimpleCommandMap(this);
@@ -176,7 +176,7 @@ public final class CraftServer implements Server {
 
     @Override
     public String getGameVersion() {
-        return getGameVersion();
+        return gameVersion;
     }
 
     @Override

--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -63,7 +63,7 @@ public final class CraftServer implements Server {
     private final String serverVersion = "1.1.10";
     private final String releaseType = "DEVELOPMENT";
     private final String protocolVersion = "1.7.3";
-    private final String gameVersion = "b1.7.3";
+    private final String GameVersion = "b1.7.3";
     private final ServicesManager servicesManager = new SimpleServicesManager();
     private final BukkitScheduler scheduler = new CraftScheduler(this);
     private final SimpleCommandMap commandMap = new SimpleCommandMap(this);
@@ -176,7 +176,7 @@ public final class CraftServer implements Server {
 
     @Override
     public String getGameVersion() {
-        return gameVersion;
+        return this.GameVersion;
     }
 
     @Override


### PR DESCRIPTION
CraftServer.getGameVersion() recursively calls itself which results in a stack overflow. I'd like for this value to be dynamic based on the actual game version in the future but since it isn't exposed in NMS theres no trivial way to do it (and the rest of the code uses the constants) so I've just made it return the gameVersion variable for now.